### PR TITLE
prevent "changed: true" when yq is installed

### DIFF
--- a/tasks/install_yaml.yml
+++ b/tasks/install_yaml.yml
@@ -3,6 +3,7 @@
   command: "yq --version"
   register: yq_result
   ignore_errors: yes
+  changed_when: false
 
 - name: set yq current version fact
   set_fact:


### PR DESCRIPTION
This is to  prevent seeing constant "changed" messages even when no changes have been made and strengthen the perception of idempotency.